### PR TITLE
Updating TLS patch to "notqmail-1.08-tls-20231230.patch"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1613,7 +1613,7 @@ base64.o md5c.o hmac_md5.o \
 dns.lib socket.lib
 	./load qmail-remote control.o constmap.o timeoutread.o \
 	timeoutwrite.o timeoutconn.o tcpto.o now.o dns.o ip.o \
-	tls.o ssl_timeoutio.o -L/usr/local/ssl/lib -lssl -lcrypto \
+	tls.o ssl_timeoutio.o -lssl -lcrypto \
 	ipalloc.o strsalloc.o ipme.o quote.o ndelay.a case.a sig.a open.a \
 	lock.a seek.a getln.a stralloc.a alloc.a substdio.a error.a \
 	base64.o md5c.o hmac_md5.o \
@@ -1721,7 +1721,7 @@ $(SMTPD_CHKUSER_OBJ)
 	./load qmail-smtpd $(SMTPD_CHKUSER_OBJ) rcpthosts.o commands.o timeoutread.o \
 	strerr.a wildmat.o qregex.o \
 	timeoutwrite.o ip.o ipme.o ipalloc.o strsalloc.o control.o \
-	tls.o ssl_timeoutio.o ndelay.a -L/usr/local/ssl/lib -lssl -lcrypto \
+	tls.o ssl_timeoutio.o ndelay.a -lssl -lcrypto \
 	constmap.o received.o date822fmt.o now.o qmail.o spf.o cdb.a \
 	fd.a wait.a datetime.a getln.a open.a sig.a case.a env.a stralloc.a qmail-spp.o \
 	alloc.a substdio.a error.a strerr.a str.a fs.a auto_qmail.o base64.o policy.o \
@@ -2027,8 +2027,7 @@ date822fmt.h date822fmt.c dns.h dns.c trylsock.c tryrsolv.c ip.h ip.c \
 ipalloc.h strsalloc.h ipalloc.c select.h1 select.h2 trysysel.c ndelay.h ndelay.c \
 ndelay_off.c direntry.3 direntry.h1 direntry.h2 trydrent.c prot.h \
 prot.c chkshsgr.c warn-shsgr tryshsgr.c ipme.h ipme.c trysalen.c \
-maildir.5 maildir.h maildir.c tcp-environ.5 constmap.h constmap.c \
-update_tmprsadh
+maildir.5 maildir.h maildir.c tcp-environ.5 constmap.h constmap.c
 	shar -m `cat FILES` > shar
 	chmod 400 shar
 

--- a/conf-cc
+++ b/conf-cc
@@ -1,3 +1,3 @@
-cc -O2 -g -DEXTERNAL_TODO -DTLS=20200107 -I/usr/local/ssl/include -I`/bin/sh ./vpopmail-dir.sh`/include
+cc -O2 -g -DEXTERNAL_TODO -DTLS=20231230 -I`/bin/sh ./vpopmail-dir.sh`/include
 
 This will be used to compile .c files.

--- a/qmail-remote.c
+++ b/qmail-remote.c
@@ -433,16 +433,13 @@ int tls_init()
     }
   }
 
-  SSL_library_init();
-  ctx = SSL_CTX_new(SSLv23_client_method());
+  OPENSSL_init_ssl(OPENSSL_INIT_LOAD_SSL_STRINGS, NULL);
+  ctx = SSL_CTX_new(TLS_client_method());
   if (!ctx) {
     if (!smtps && !servercert) return 0;
     smtptext.len = 0;
     tls_quit_error("ZTLS error initializing ctx");
   }
-
-  /* POODLE vulnerability */
-  SSL_CTX_set_options(ctx, SSL_OP_NO_SSLv2 | SSL_OP_NO_SSLv3);
 
   if (servercert) {
     if (!SSL_CTX_load_verify_locations(ctx, servercert, NULL)) {
@@ -483,7 +480,10 @@ int tls_init()
     ciphers = saciphers.s;
   }
   else ciphers = "DEFAULT";
+  /* TLSv1.2 and lower*/
   SSL_set_cipher_list(myssl, ciphers);
+  /* TLSv1.3 and above*/
+  SSL_set_ciphersuites(myssl, ciphers);
   alloc_free(saciphers.s);
 
   SSL_set_fd(myssl, smtpfd);

--- a/qmail-smtpd.c
+++ b/qmail-smtpd.c
@@ -2118,69 +2118,6 @@ void smtp_tls(char *arg)
   else tls_init();
 }
 
-RSA *tmp_rsa_cb(SSL *ssl, int export, int keylen)
-{
-  RSA *rsa;
-
-  if (!export) keylen = 4096;
-  if (keylen == 4096) {
-    FILE *in = fopen("control/rsa4096.pem", "r");
-    if (in) {
-      rsa = PEM_read_RSAPrivateKey(in, NULL, NULL, NULL);
-      fclose(in);
-      if (rsa) return rsa;
-    }
-  }
-#if OPENSSL_VERSION_NUMBER >= 0x10100000L
-  BIGNUM *e; /*exponent */
-  e = BN_new();
-  BN_set_word(e, RSA_F4);
-  if (RSA_generate_key_ex(rsa, keylen, e, NULL) == 1)
-    return rsa;
-  return NULL;
-#else
-  return RSA_generate_key(keylen, RSA_F4, NULL, NULL);
-#endif
-}
-
-DH *tmp_dh_cb(SSL *ssl, int export, int keylen)
-{
-  DH *dh;
-
-  if (!export) keylen = 4096;
-  if (keylen == 4096) {
-    FILE *in = fopen("control/dh4096.pem", "r");
-    if (in) {
-      dh = PEM_read_DHparams(in, NULL, NULL, NULL);
-      fclose(in);
-      if (dh) return dh;
-    }
-  }
-  if (keylen == 2048) {
-    FILE *in = fopen("control/dh2048.pem", "r");
-    if (in) {
-      DH *dh = PEM_read_DHparams(in, NULL, NULL, NULL);
-      fclose(in);
-      if (dh) return dh;
-    }
-  }
-  if (keylen == 1024) {
-    FILE *in = fopen("control/dh1024.pem", "r");
-    if (in) {
-      DH *dh = PEM_read_DHparams(in, NULL, NULL, NULL);
-      fclose(in);
-      if (dh) return dh;
-    }
-  }
-#if OPENSSL_VERSION_NUMBER >= 0x10100000L
-  if((dh = DH_new()) && (DH_generate_parameters_ex(dh, keylen, DH_GENERATOR_2, NULL) == 1))
-    return dh;
-  return NULL;
-#else
-  return DH_generate_parameters(keylen, DH_GENERATOR_2, NULL, NULL);
-#endif
-}
-
 /* don't want to fail handshake if cert isn't verifiable */
 int verify_cb(int preverify_ok, X509_STORE_CTX *x509_ctx) { return 1; }
 
@@ -2294,14 +2231,11 @@ void tls_init()
   X509_LOOKUP *lookup;
   int session_id_context = 1; /* anything will do */
 
-  SSL_library_init();
+  OPENSSL_init_ssl(OPENSSL_INIT_LOAD_SSL_STRINGS, NULL);
 
   /* a new SSL context with the bare minimum of options */
-  ctx = SSL_CTX_new(SSLv23_server_method());
+  ctx = SSL_CTX_new(TLS_server_method());
   if (!ctx) { tls_err("unable to initialize ctx"); return; }
-
-  /* POODLE vulnerability */
-  SSL_CTX_set_options(ctx, SSL_OP_NO_SSLv2 | SSL_OP_NO_SSLv3);
 
   /* renegotiation should include certificate request */
   SSL_CTX_set_options(ctx, SSL_OP_NO_SESSION_RESUMPTION_ON_RENEGOTIATION);
@@ -2331,12 +2265,9 @@ void tls_init()
     X509_STORE_set_flags(store, X509_V_FLAG_CRL_CHECK |
                                 X509_V_FLAG_CRL_CHECK_ALL);
 
-#if OPENSSL_VERSION_NUMBER >= 0x10002000L
-  /* support ECDH */
-  SSL_CTX_set_ecdh_auto(ctx,1);
-#endif
-
   SSL_CTX_set_verify(ctx, SSL_VERIFY_NONE, NULL);
+
+  SSL_CTX_set_dh_auto(ctx, 1);
 
   /* a new SSL object, with the rest added to it directly to avoid copying */
   myssl = SSL_new(ctx);
@@ -2359,11 +2290,12 @@ void tls_init()
     }
   }
   if (!ciphers || !*ciphers) ciphers = "DEFAULT";
+  /* TLSv1.2 and lower*/
   SSL_set_cipher_list(myssl, ciphers);
+  /* TLSv1.3 and above*/
+  SSL_set_ciphersuites(myssl, ciphers);
   alloc_free(saciphers.s);
 
-  SSL_set_tmp_rsa_callback(myssl, tmp_rsa_cb);
-  SSL_set_tmp_dh_callback(myssl, tmp_dh_cb);
   SSL_set_rfd(myssl, ssl_rfd = substdio_fileno(&ssin));
   SSL_set_wfd(myssl, ssl_wfd = substdio_fileno(&ssout));
 

--- a/update_tmprsadh.sh
+++ b/update_tmprsadh.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # Update temporary RSA and DH keys
-# Frederik Vermeulen 2004-05-31 GPL
+# Frederik Vermeulen 2023-12-28 GPL
 #
 # Slightly modified by Roberto Puzzanghera
 #
@@ -10,8 +10,6 @@
 # as a different user.
 
 umask 0077 || exit 0
-
-export PATH="$PATH:/usr/local/bin/ssl:/usr/sbin"
 
 openssl genrsa -out QMAIL/control/rsa4096.new 4096 &&
 chmod 600 QMAIL/control/rsa4096.new &&


### PR DESCRIPTION
I couldn't come up with any reasonable way to apply the author's TLS patch to your (already very patched) repo files.So instead: 

I made two clean netqmail-1.0.6 trees.  To one I applied netqmail-1.06-tls-20200107.patch, and the other notqmail-1.08-tls-20231230.patch, then diffed them.  (this was actually easier than trying to diff the patches)  

Reviewing that clean set of 2020->2023 TLS differences, it was easy to manually apply each one to *your* tree.

I hope there's an easier way to do this for you applying new patches! 