### PR TITLE
Make the `dkimsign` binary _not_ derive the "d=" domain value from the `Return-Path` header

### DIFF
--- a/dkimsign.cpp
+++ b/dkimsign.cpp
@@ -426,10 +426,6 @@ bool CDKIMSign::ParseFromAddress(void)
 	string          sAddress;
 	char           *p, *at;
 
-	/* thanks to fred */
-	if (!sReturnPath.empty())
-		sAddress.assign(sReturnPath);
-	else
 	if (!sSender.empty())
 		sAddress.assign(sSender);
 	else


### PR DESCRIPTION
Currently, `dkimsign` will use the domain found in a `Return-Path` header with highest preference.

That is, when processing a message where headers already include a `Return-Path`, the "d=" DKIM tag will be that of the Return-Path, whereas for a message without a `Return-Path`, it will be the domain taken from the `From` header field.

I was unable to find out why exactly `Return-Path` handling was added in the first place. I don't see the purpose of having a signature for the Return-Path, since I have never seen the Return-Path being verified at any stage. Also, https://datatracker.ietf.org/doc/html/rfc6376#section-5.4 says that

> Signers SHOULD NOT sign an existing header field likely to be legitimately modified or removed in transit.  In particular, [RFC5321] explicitly permits modification or removal of the Return-Path header field in transit.

If a signature for the Return-Path would be issued, at least it should be _in addition_ to one for the From: domain, not _instead of_ it.