### PR TITLE
Fix dh key too small

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,13 @@ This distribution of qmail puts together netqmail-1.06 with the following patche
   by Krysztof Dabrowski and Bjoern Kalkbrenner.
   It provides cram-md5, login, plain authentication support for qmail-smtpd and qmail-remote.
   http://www.fehcom.de/qmail/smtpauth.html##PATCHES
-* Frederik Vermeulen's qmail-tls patch v. 20231230
-  implements SSL or TLS encrypted and authenticated SMTP.
-  The key is now 4096 bit long and the cert will be owned by vpopmail:vchkpw
+* Frederik Vermeulen's qmail-tls patch v. 20231230  
+  implements SSL or TLS encrypted and authenticated SMTP.  
+  The key is now 4096 bit long and the cert will be owned by vpopmail:vchkpw  
+  Patched to dinamically touch control/notlshosts/<fqdn> if control/notlshosts_auto contains any
+  number greater than 0 in order to skip the TLS connection for remote servers with an obsolete TLS version.  
+  The file update_tmprsadh was modified to chown all .pem files to vpopmail.  
   http://inoa.net/qmail-tls/
-  The file update_tmprsadh was modified to chown all .pem files to vpopmail.
 * Marcel Telka's force-tls patch v. 2016.05.15
   optionally gets qmail to require TLS before authentication to improve security.
   You have to declare FORCETLS=0 if you want to allow the auth without TLS

--- a/hier.c
+++ b/hier.c
@@ -40,6 +40,7 @@ void hier()
 
   d(auto_qmail,"control",auto_uido,auto_gidq,0755);
   d(auto_qmail,"control/cache",auto_uidv,auto_gidv,0755);
+  d(auto_qmail,"control/notlshosts",auto_uidr,auto_gidq,0755);
   d(auto_qmail,"users",auto_uido,auto_gidq,0755);
   d(auto_qmail,"bin",auto_uido,auto_gidq,0755);
   d(auto_qmail,"boot",auto_uido,auto_gidq,0755);

--- a/qmail-remote.c
+++ b/qmail-remote.c
@@ -1,5 +1,4 @@
 #include <pwd.h>
-#include <unistd.h>
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <netinet/in.h>

--- a/qmail-remote.c
+++ b/qmail-remote.c
@@ -382,9 +382,9 @@ void tls_quit(const char *s1, const char *s2)
      servers with an obsolete TLS version.
      Thanks Alexandre Fonseca
    */
-  struct passwd *info = getpwuid(getuid()); // get qmail dir
   unsigned long i = 0;
   if (control_readint(&i,"control/notlshosts_auto") && i) {
+    struct passwd *info = getpwuid(getuid()); // get qmail dir
     FILE *fp;
     char acfcommand[1200];
     sprintf(acfcommand, "/bin/touch %s/control/notlshosts/'%s'", info->pw_dir, partner_fqdn);

--- a/qmail-remote.c
+++ b/qmail-remote.c
@@ -377,8 +377,9 @@ char *partner_fqdn = 0;
 void tls_quit(const char *s1, const char *s2)
 {
   /*
-     skip TLS connection if control/notlshosts/<fqdn> exists and
-     control/notlshosts_auto contains any number greater than 0
+     touch control/notlshosts/<fqdn> if control/notlshosts_auto contains any
+     number greater than 0 in order to skip the TLS connection for remote
+     servers with an obsolete TLS version.
      Thanks Alexandre Fonseca
    */
   struct passwd *info = getpwuid(getuid()); // get qmail dir

--- a/qmail-remote.c
+++ b/qmail-remote.c
@@ -382,11 +382,7 @@ void tls_quit(const char *s1, const char *s2)
      control/notlshosts_auto contains any number greater than 0
      Thanks Alexandre Fonseca
    */
-  // get qmail dir
-  uid_t qmailruid;
-  qmailruid = getuid();
-  struct passwd *info = getpwuid(getuid());
-
+  struct passwd *info = getpwuid(getuid()); // get qmail dir
   unsigned long i = 0;
   if (control_readint(&i,"control/notlshosts_auto") && i) {
     FILE *fp;

--- a/qmail-remote.c
+++ b/qmail-remote.c
@@ -380,7 +380,7 @@ void tls_quit(const char *s1, const char *s2)
      touch control/notlshosts/<fqdn> if control/notlshosts_auto contains any
      number greater than 0 in order to skip the TLS connection for remote
      servers with an obsolete TLS version.
-     Thanks Alexandre Fonseca
+     Thanks Alexandre Fonceca
    */
   unsigned long i = 0;
   if (control_readint(&i,"control/notlshosts_auto") && i) {


### PR DESCRIPTION
tls_quit function inside qmail-remote.c patched to dinamically touch control/notlshosts/<fqdn> if control/notlshosts_auto contains any number greater than 0 in order to skip the TLS connection for remote servers with an obsolete TLS version.  
Thanks Alexandre Fonceca