### PR TITLE
Add support for EAI (RFC 5336 SMTP Email Address Internationalization) support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1617,7 +1617,7 @@ dns.lib socket.lib
 	ipalloc.o strsalloc.o ipme.o quote.o ndelay.a case.a sig.a open.a \
 	lock.a seek.a getln.a stralloc.a alloc.a substdio.a error.a \
 	base64.o md5c.o hmac_md5.o \
-	str.a fs.a auto_qmail.o `cat dns.lib` `cat socket.lib`
+	str.a fs.a auto_qmail.o `cat dns.lib` `cat socket.lib` -lidn2
 
 qmail-remote.0: \
 qmail-remote.8

--- a/Makefile
+++ b/Makefile
@@ -1593,7 +1593,6 @@ env.a control.o constmap.o str.a fs.a auto_qmail.o auto_split.o auto_uids.o
         date822fmt.o wildmat.o qregex.o env.a control.o constmap.o datetime.a case.a seek.a ndelay.a open.a sig.a \
         getln.a stralloc.a alloc.a substdio.a error.a str.a fs.a auto_qmail.o auto_split.o auto_uids.o
 
-
 qmail-queue.0: \
 qmail-queue.8
 	nroff -man qmail-queue.8 > qmail-queue.0
@@ -1604,19 +1603,23 @@ alloc.h substdio.h datetime.h now.h datetime.h triggerpull.h extra.h \
 auto_qmail.h auto_uids.h date822fmt.h fmtqfn.h
 	./compile qmail-queue.c
 
+eai.o: \
+compile eai.c
+	./compile eai.c
+
 qmail-remote: \
 load qmail-remote.o control.o constmap.o timeoutread.o timeoutwrite.o \
 timeoutconn.o tcpto.o now.o dns.o ip.o ipalloc.o strsalloc.o ipme.o quote.o \
 ndelay.a case.a sig.a open.a lock.a seek.a getln.a stralloc.a alloc.a \
 substdio.a error.a str.a fs.a auto_qmail.o \
-base64.o md5c.o hmac_md5.o \
+base64.o md5c.o hmac_md5.o eai.o \
 dns.lib socket.lib
 	./load qmail-remote control.o constmap.o timeoutread.o \
 	timeoutwrite.o timeoutconn.o tcpto.o now.o dns.o ip.o \
 	tls.o ssl_timeoutio.o -lssl -lcrypto \
 	ipalloc.o strsalloc.o ipme.o quote.o ndelay.a case.a sig.a open.a \
 	lock.a seek.a getln.a stralloc.a alloc.a substdio.a error.a \
-	base64.o md5c.o hmac_md5.o \
+	base64.o md5c.o hmac_md5.o eai.o \
 	str.a fs.a auto_qmail.o `cat dns.lib` `cat socket.lib` -lidn2
 
 qmail-remote.0: \

--- a/README.md
+++ b/README.md
@@ -4,6 +4,18 @@
 
 ## My patched qmail
 
+This `qmail` package is part of a [complete `qmail` guide](https://notes.sagredo.eu/en/qmail-notes-185/qmail-vpopmail-dovecot-roberto-s-qmail-notes-8.html). Not everything you need to know about `qmail` or its installation is covered here so, in case of issues in the installation, have a look at the link above.
+
+## Before installing
+
+This `qmail` package contains `chkuser`, which has [`vpopmail`](https://notes.sagredo.eu/en/qmail-notes-185/installing-and-configuring-vpopmail-81.html) as a prerequisite, while `vpopmail` itself requires to be installed over the vanilla `qmail`. So the compilation chain is [`netqmail`](https://notes.sagredo.eu/en/qmail-notes-185/netqmail-106-basic-setup-42.html) > [`vpopmail`](https://notes.sagredo.eu/en/qmail-notes-185/installing-and-configuring-vpopmail-81.html) > patched `qmail`.
+
+This package requires the [`libidn2`](https://gitlab.com/libidn/libidn2) library (GNU Internationalized Domain Name library version 2, `libidn2-dev` on `Debian` like OSs)
+
+If you are looking for a `qmail` variant without `chkuser` and `vpopmail` you can switch to the [specific branch](https://github.com/sagredo-dev/qmail/tree/no-chkuser-vpopmail) where you can find this same `qmail` without `chkuser`, or apply [this patch](https://github.com/sagredo-dev/qmail/blob/main/other-patches/qmail-remove_chkuser_vpopmail.patch).
+
+## `qmail` package details
+
 More info at https://notes.sagredo.eu/en/qmail-notes-185/patching-qmail-82.html
 
 This distribution of qmail puts together netqmail-1.06 with the following patches (more info in the [README](https://github.com/sagredo-dev/qmail/blob/main/README) file):

--- a/README.md
+++ b/README.md
@@ -224,6 +224,11 @@ This distribution of qmail puts together netqmail-1.06 with the following patche
   This patch modifies blast to scan the message in larger chunks. I have benchmarked before and after, and the change
   reduced the CPU time consumed by qmail-remote by a factor of 10.  
   http://untroubled.org/qmail/qmail-1.03-fastremote-3.patch
+* Arnt Gulbrandsen's smtputf8  
+  adds RFC 5336 SMTP Email Address Internationalization support  
+  https://github.com/arnt/qmail-smtputf8/tree/smtputf8-tls  
+  https://github.com/sagredo-dev/qmail/compare/main...smtputf8-arnt
+
 
 Usage
 -----

--- a/TARGETS
+++ b/TARGETS
@@ -464,3 +464,4 @@ getDomainToken.o
 parse_env.o
 dns_text.o
 conf-policy.temp
+eai.o

--- a/eai.c
+++ b/eai.c
@@ -1,0 +1,101 @@
+#include "eai.h"
+#include "case.h"
+#include "str.h"
+#include "stralloc.h"
+#include "substdio.h"
+#include "subfd.h"
+
+extern void temp_read();
+extern void temp_nomem();
+
+int containsutf8(unsigned char *p, int l)
+{
+  int i = 0;
+  while (i<l)
+    if(p[i++] > 127) return 1;
+  return 0;
+}
+
+void checkutf8message()
+{
+  GEN_ALLOC_typedef(saa,stralloc,sa,len,a)
+
+  int pos;
+  int i;
+  int r;
+  char ch;
+  int state;
+  extern stralloc sender;
+  extern saa reciplist;
+  extern substdio ssin;
+
+  if (containsutf8(sender.s, sender.len)) { utf8message = 1; return; }
+  for (i = 0;i < reciplist.len;++i)
+    if (containsutf8(reciplist.sa[i].s, reciplist.sa[i].len)) {
+      utf8message = 1;
+      return;
+    }
+  state = 0;
+  pos = 0;
+  for (;;) {
+    r = substdio_get(&ssin,&ch,1);
+    if (r == 0) break;
+    if (r == -1) temp_read();
+    if (ch == '\n' && !stralloc_cats(&firstpart,"\r")) temp_nomem();
+    if (!stralloc_append(&firstpart,&ch)) temp_nomem();
+    if (ch == '\r')
+      continue;
+    if (ch == '\t')
+      ch = ' ';
+    switch (state) {
+    case 6: /* in Received, at LF but before WITH clause */
+      if (ch == ' ') { state = 3; pos = 1; continue; }
+      state = 0;
+      /* FALL THROUGH */
+    case 0: /* start of header field */
+      if (ch == '\n') return;
+      state = 1;
+      pos = 0;
+      /* FALL THROUGH */
+    case 1: /* partway through "Received:" */
+      if (ch != "RECEIVED:"[pos] && ch != "received:"[pos]) { state = 2; continue; }
+      if (++pos == 9) { state = 3; pos = 0; }
+      continue;
+    case 2: /* other header field */
+      if (ch == '\n') state = 0;
+      continue;
+    case 3: /* in Received, before WITH clause or partway though " with " */
+      if (ch == '\n') { state = 6; continue; }
+      if (ch != " WITH "[pos] && ch != " with "[pos]) { pos = 0; continue; }
+      if (++pos == 6) { state = 4; pos = 0; }
+      continue;
+    case 4: /* in Received, having seen with, before the argument */
+      if (pos == 0 && (ch == ' ' || ch == '\t')) continue;
+      if (ch != "UTF8"[pos] && ch != "utf8"[pos]) { state = 5; continue; }
+      if(++pos == 4) { utf8message = 1; state = 5; continue; }
+      continue;
+    case 5: /* after the RECEIVED WITH argument */
+      /* blast() assumes that it copies whole lines */
+      if (ch == '\n') return;
+      state = 1;
+      pos = 0;
+      continue;
+    }
+  }
+}
+
+/*
+  returns 1 if the remote server advertises a specific verb
+  tx notqmail/mbhangui-smtputf8
+ */
+int get_capa(const char *capa)
+{
+  int i = 0, len;
+  len = str_len(capa);
+  extern stralloc smtptext;
+
+  for (i = 0; i < smtptext.len-len; ++i) {
+    if (case_starts(smtptext.s+i,capa)) return 1;
+  }
+  return 0;
+}

--- a/eai.c
+++ b/eai.c
@@ -28,6 +28,8 @@ void checkutf8message()
   extern stralloc sender;
   extern saa reciplist;
   extern substdio ssin;
+  extern stralloc firstpart;
+  extern int utf8message;
 
   if (containsutf8(sender.s, sender.len)) { utf8message = 1; return; }
   for (i = 0;i < reciplist.len;++i)

--- a/eai.h
+++ b/eai.h
@@ -1,0 +1,9 @@
+#include "stralloc.h"
+
+extern stralloc asciihost;
+extern stralloc firstpart;
+extern int utf8message;
+
+int containsutf8(unsigned char *, int);
+void checkutf8message();
+int get_capa(const char *);

--- a/eai.h
+++ b/eai.h
@@ -1,9 +1,3 @@
-#include "stralloc.h"
-
-extern stralloc asciihost;
-extern stralloc firstpart;
-extern int utf8message;
-
 int containsutf8(unsigned char *, int);
 void checkutf8message();
 int get_capa(const char *);

--- a/qmail-remote.8
+++ b/qmail-remote.8
@@ -47,6 +47,12 @@ arguments to
 The envelope sender address is listed as
 .I sender\fP.
 
+.B qmail-remote
+will respect SMTPUTF8 and EAI addresses. If message is utf8,
+.B qmail-remote
+will use idn2_lookup_u8(3) to perform IDNA2008 lookup string conversion on
+.IR host .
+
 Note that
 .B qmail-remote
 does not take options

--- a/qmail-remote.c
+++ b/qmail-remote.c
@@ -32,6 +32,7 @@
 #include "timeoutwrite.h"
 #include "base64.h"
 #include "hmac_md5.h"
+#include "eai.h"
 
 #define HUGESMTPTEXT 5000
 
@@ -48,6 +49,8 @@ stralloc routes = {0};
 struct constmap maproutes;
 stralloc host = {0};
 stralloc asciihost = {0};
+stralloc firstpart = {0};
+int utf8message = 0;
 stralloc sender = {0};
 
 stralloc authsenders = {0};
@@ -180,7 +183,6 @@ char smtpfrombuf[128];
 substdio smtpfrom = SUBSTDIO_FDBUF(saferead,-1,smtpfrombuf,sizeof smtpfrombuf);
 
 stralloc smtptext = {0};
-stralloc firstpart = {0};
 
 void get(ch)
 char *ch;
@@ -597,92 +599,6 @@ int tls_init()
 #endif
 
 stralloc recip = {0};
-
-int containsutf8(p, l) unsigned char * p; int l;
-{
-  int i = 0;
-  while (i<l)
-    if(p[i++] > 127) return 1;
-  return 0;
-}
-
-int utf8message = 0;
-
-void checkutf8message()
-{
-  int pos;
-  int i;
-  int r;
-  char ch;
-  int state;
-  if (containsutf8(sender.s, sender.len)) { utf8message = 1; return; }
-  for (i = 0;i < reciplist.len;++i)
-    if (containsutf8(reciplist.sa[i].s, reciplist.sa[i].len)) {
-      utf8message = 1;
-      return;
-    }
-  state = 0;
-  pos = 0;
-  for (;;) {
-    r = substdio_get(&ssin,&ch,1);
-    if (r == 0) break;
-    if (r == -1) temp_read();
-    if (ch == '\n' && !stralloc_cats(&firstpart,"\r")) temp_nomem();
-    if (!stralloc_append(&firstpart,&ch)) temp_nomem();
-    if (ch == '\r')
-      continue;
-    if (ch == '\t')
-      ch = ' ';
-    switch (state) {
-    case 6: /* in Received, at LF but before WITH clause */
-      if (ch == ' ') { state = 3; pos = 1; continue; }
-      state = 0;
-      /* FALL THROUGH */
-    case 0: /* start of header field */
-      if (ch == '\n') return;
-      state = 1;
-      pos = 0;
-      /* FALL THROUGH */
-    case 1: /* partway through "Received:" */
-      if (ch != "RECEIVED:"[pos] && ch != "received:"[pos]) { state = 2; continue; }
-      if (++pos == 9) { state = 3; pos = 0; }
-      continue;
-    case 2: /* other header field */
-      if (ch == '\n') state = 0;
-      continue;
-    case 3: /* in Received, before WITH clause or partway though " with " */
-      if (ch == '\n') { state = 6; continue; }
-      if (ch != " WITH "[pos] && ch != " with "[pos]) { pos = 0; continue; }
-      if (++pos == 6) { state = 4; pos = 0; }
-      continue;
-    case 4: /* in Received, having seen with, before the argument */
-      if (pos == 0 && (ch == ' ' || ch == '\t')) continue;
-      if (ch != "UTF8"[pos] && ch != "utf8"[pos]) { state = 5; continue; }
-      if(++pos == 4) { utf8message = 1; state = 5; continue; }
-      continue;
-    case 5: /* after the RECEIVED WITH argument */
-      /* blast() assumes that it copies whole lines */
-      if (ch == '\n') return;
-      state = 1;
-      pos = 0;
-      continue;
-    }
-  }
-}
-
-/*
-  returns 1 if the remote server advertises a specific verb
-  tx notqmail/mbhangui-smtputf8
- */
-int get_capa(const char *capa)
-{
-  int i = 0, len;
-  len = str_len(capa);
-  for (i = 0; i < smtptext.len-len; ++i) {
-    if (case_starts(smtptext.s+i,capa)) return 1;
-  }
-  return 0;
-}
 
 void mailfrom()
 {

--- a/qmail-remote.c
+++ b/qmail-remote.c
@@ -671,7 +671,7 @@ void checkutf8message()
 }
 
 /*
-  returns 1 if the remote server advertizes a specific verb
+  returns 1 if the remote server advertises a specific verb
   tx notqmail/mbhangui-smtputf8
  */
 int get_capa(const char *capa)

--- a/qmail-smtpd.8
+++ b/qmail-smtpd.8
@@ -24,6 +24,11 @@ normally on port 465). Otherwise,
 offers the STARTTLS extension to ESMTP.
 
 .B qmail-smtpd
+offers RFC 5336 SMTP Email Address Internationalization support and will advertize the
+capability in the EHLO greeting. Since qmail-smtpd is 8 bit clean, setting of SMTPUTF8 has no real
+consequences except for displaying this setting in the received headers as \fBUTF8SMTP\fR.
+
+.B qmail-smtpd
 is responsible for counting hops.
 It rejects any message with 100 or more 
 .B Received
@@ -32,9 +37,11 @@ or
 header fields.
 
 .B qmail-smtpd
-supports ESMTP, including the 8BITMIME, DATA, PIPELINING, SIZE, and AUTH options.
+supports ESMTP, including the 8BITMIME, DATA, PIPELINING, SIZE, SMTPUTF8 and AUTH options.
+
 .B qmail-smtpd
 includes a \'MAIL FROM:\' parameter parser and obeys \'Auth\' and \'Size\' advertisements.
+
 .B qmail-smtpd
 can accept LOGIN, PLAIN, and CRAM-MD5 AUTH types. It invokes
 .IR checkprogram ,

--- a/qmail-smtpd.c
+++ b/qmail-smtpd.c
@@ -2410,7 +2410,8 @@ struct commands smtpcommands[] = {
 /* qsmtpdlog: start */
 void outqlog(const char *s, unsigned int n) {
   while (n > 0) {
-    substdio_put(&sslog,((*s > 32) && (*s <= 126)) ? s : "_",1);
+//    substdio_put(&sslog,((*s > 32) && (*s <= 126)) ? s : "_",1);
+    substdio_put(&sslog,s,1);
     --n;
     ++s;
   }


### PR DESCRIPTION
This PR adds support for EAI (RFC 5336 SMTP Email Address Internationalization). Patch grabbed from https://github.com/arnt/qmail-smtputf8/tree/smtputf8-tls.