### PR TITLE
make_mav() function in chkuser.c should return 1 if check passed

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,11 +242,10 @@ This distribution of `qmail` puts together `netqmail-1.06` with the following pa
   This patch modifies blast to scan the message in larger chunks. I have benchmarked before and after, and the change
   reduced the CPU time consumed by qmail-remote by a factor of 10.  
   http://untroubled.org/qmail/qmail-1.03-fastremote-3.patch
-* Arnt Gulbrandsen's smtputf8  
-  adds RFC 5336 SMTP Email Address Internationalization support  
-  You have to undefine CHKUSER_SENDER_FORMAT in chkuser_settings.h to get this feature working.  
-  https://github.com/arnt/qmail-smtputf8/tree/smtputf8-tls  
-  Pull Request details: https://github.com/sagredo-dev/qmail/pull/13
+* [Arnt Gulbrandsen's smtputf8](https://github.com/arnt/qmail-smtputf8/tree/smtputf8-tls)  
+  adds [RFC 5336](https://datatracker.ietf.org/doc/html/rfc5336) SMTP Email Address Internationalization support  
+  - [Pull Request](https://github.com/sagredo-dev/qmail/pull/13)  
+  - More infor [here](https://notes.sagredo.eu/en/qmail-notes-185/email-address-internationalization-for-qmail-mav-from-chkuser-modified-accordingly-308.html)
 
 Install
 -----
@@ -271,7 +270,6 @@ cd ../
 
 * Download and compile
 ```
-make
 make setup check
 ```
 
@@ -282,4 +280,4 @@ make setup check
 
 Info and support
 ----------------
-You can find more info and ask for support here https://notes.sagredo.eu/en/qmail-notes-185/patching-qmail-82.html.
+You can find more info and ask for support [here](https://notes.sagredo.eu/en/qmail-notes-185/patching-qmail-82.html).

--- a/README.md
+++ b/README.md
@@ -3,17 +3,14 @@
 [`qmail`](http://cr.yp.to/qmail.html) is a secure, reliable, efficient, simple message transfer agent. It is designed for typical Internet-connected UNIX hosts.
 It was developed by [D. J. Bernstein](http://cr.yp.to/djb.html).
 
-## My patched `qmail`
-
-This `qmail` package is part of a [complete `qmail` guide](https://notes.sagredo.eu/en/qmail-notes-185/qmail-vpopmail-dovecot-roberto-s-qmail-notes-8.html).
+This `qmail` distribution is part of a [complete `qmail` guide](https://notes.sagredo.eu/en/qmail-notes-185/qmail-vpopmail-dovecot-roberto-s-qmail-notes-8.html).
 Not everything you need to know about `qmail` or its installation is covered here so, in case of issues in the installation, have a look at the link above.
-
-## Before installing
 
 This `qmail` package contains `chkuser`, which has [`vpopmail`](https://notes.sagredo.eu/en/qmail-notes-185/installing-and-configuring-vpopmail-81.html) as a prerequisite,
 while `vpopmail` itself requires to be installed over the vanilla `qmail`. So the compilation chain is [`netqmail`](https://notes.sagredo.eu/en/qmail-notes-185/netqmail-106-basic-setup-42.html) > [`vpopmail`](https://notes.sagredo.eu/en/qmail-notes-185/installing-and-configuring-vpopmail-81.html) > patched `qmail`.
 
-If you are looking for a `qmail` variant without `chkuser` and `vpopmail` you can switch to the [specific branch](https://github.com/sagredo-dev/qmail/tree/no-chkuser-vpopmail) where you can find this same `qmail` without `chkuser`.  
+If you are looking for a `qmail` variant without `chkuser` and `vpopmail` you can switch to the [specific branch](https://github.com/sagredo-dev/qmail/tree/no-chkuser-vpopmail)
+where you can find this same `qmail` without `chkuser`.  
 Download like this:  
 
 ```
@@ -245,7 +242,7 @@ This distribution of `qmail` puts together `netqmail-1.06` with the following pa
 * [Arnt Gulbrandsen's smtputf8](https://github.com/arnt/qmail-smtputf8/tree/smtputf8-tls)  
   adds [RFC 5336](https://datatracker.ietf.org/doc/html/rfc5336) SMTP Email Address Internationalization support  
   - [Pull Request](https://github.com/sagredo-dev/qmail/pull/13)  
-  - More infor [here](https://notes.sagredo.eu/en/qmail-notes-185/email-address-internationalization-for-qmail-mav-from-chkuser-modified-accordingly-308.html)
+  - More info [here](https://notes.sagredo.eu/en/qmail-notes-185/email-address-internationalization-for-qmail-mav-from-chkuser-modified-accordingly-308.html)
 
 Install
 -----

--- a/chkuser.c
+++ b/chkuser.c
@@ -59,7 +59,6 @@ extern char *remoteip;
 extern char *remoteinfo;
 extern char *relayclient;
 extern char *fakehelo;
-extern int  smtputf8;
 
 extern void die_nomem();
 
@@ -244,6 +243,11 @@ static void chkuser_commonlog (char *sender, char *rcpt, char *title, char *desc
 #define chkuser_commonlog(a,b,c,d) /* no log */
 #endif
 
+
+#if defined CHKUSER_SENDER_FORMAT || defined CHKUSER_RCPT_FORMAT
+
+extern int  smtputf8;
+
 /**************************************************************************
  *
  * Performs mail sender/rcpt address verification
@@ -317,10 +321,13 @@ static int make_mav(stralloc *user, stralloc *domain) {
       || strstr(domain->s, "-.") != NULL
       || strchr(domain->s, '.') == NULL
       || ( !smtputf8 && (strncmp(domain->s, "xn--", 4) == 0) && (strstr(&domain->s[4], "--") != NULL) ) // do no accept punycode if SMTPUTF8 not avaliable
-      // allowing domains with double hyphens like y--s.co.jp not in 1st char
+      // allowing domains with double hyphen like y--s.co.jp not in 1st char
       // || strstr(domain->s, "--") != NULL
      ) return 0;
+
+  return 1;
 }
+#endif
 
 
 #if defined CHKUSER_SENDER_MX || defined CHKUSER_RCPT_MX

--- a/chkuser_settings.h
+++ b/chkuser_settings.h
@@ -187,12 +187,6 @@
 #define CHKUSER_SENDER_DELAY_ANYERROR
 
 
-/***************************************************
- *
- *      new/modified defines in/from 2.0.6
- *
- **************************************************/
-
 /*
  * Before version 5.3.25, vpopmail used the function vget_real_domain()
  * to get the real name of a domain (useful if rcpt domain is aliasing
@@ -205,11 +199,6 @@
  */
 /* #define CHKUSER_ENABLE_VGET_REAL_DOMAIN */
 
-/***************************************************
- *
- *      new/modified defines in/from 2.0.7
- *
- **************************************************/
 
 /*
  * Uncomment next define to accept recipients for
@@ -277,19 +266,6 @@
  */
 #define CHKUSER_DB_CLEANUP
 
-/***************************************************
- *
- *      new/modified defines in/from 2.0.8
- *
- **************************************************/
-
-/*
- * The following defines are NO MORE used. NULL SENDER rejecting breaks RFC
- * compatibility, and makes harder to handle e-mail receipts.
- * Please comment or delete them from your chkuser_settings.h.
- */
-/* #define CHKUSER_ACCEPT_NULL_SENDER */
-/* #define CHKUSER_ENABLE_NULL_SENDER_WITH_TCPREMOTEHOST */
 
 /*
  * Uncomment to enable checking of user and domain format for rcpt addresses
@@ -298,7 +274,7 @@
  *                      or only alphanum chars with CHKUSER_ALLOWED_CHARS additions will be allowed
  *      domain  =       any UTF8 character in the world EXCEPT CHKUSER_INVALID_UTF8_CHARS with not consecutive "-.", not leading or ending "-."
  *                      provided that SMTPUTF8 was advertised by the remote client in MAIL FROM
- *                      or only alphanum chars with CHKUSER_ALLOWED_CHARS additions will be allowed
+ *                      otherwise only alphanum chars with CHKUSER_ALLOWED_CHARS additions will be allowed
  */
 #define CHKUSER_RCPT_FORMAT
 
@@ -315,7 +291,7 @@
  *                      or only alphanum chars with CHKUSER_ALLOWED_CHARS additions will be allowed
  *      domain  =       any UTF8 character in the world EXCEPT CHKUSER_INVALID_UTF8_CHARS with not consecutive "-.", not leading or ending "-."
  *                      provided that SMTPUTF8 was advertised by the remote client in MAIL FROM
- *                      or only alphanum chars with CHKUSER_ALLOWED_CHARS additions will be allowed
+ *                      otherwise only alphanum chars with CHKUSER_ALLOWED_CHARS additions will be allowed
  */
 #define CHKUSER_SENDER_FORMAT
 
@@ -331,11 +307,6 @@
  */
 #define CHKUSER_ERROR_DELAY_INCREASE 300
 
-/***************************************************
- *
- *      new/modified defines in/from 2.0.9
- *
- **************************************************/
 
 /*
  * A new class of defines is introduced
@@ -363,7 +334,6 @@
  * If you are using MySQL with separate servers for read and write use #define CHKUSER_VAUTH_OPEN_CALL vauth_open
  * If you are using other DB, check the most appropriate function for your DB within dedicated vpopmail module
  *
- * This define substitutes CHKUSER_ENABLE_VAUTH_OPEN
  */
 
 /* #define CHKUSER_VAUTH_OPEN_CALL vauth_open   */
@@ -401,9 +371,9 @@
 #define CHKUSER_MAXRCPT_STRING "550 5.5.3 sorry, reached maximum number of recipients allowed in one session (chkuser)\r\n"
 #define CHKUSER_MAXWRONGRCPT_STRING "550 5.5.3 sorry, you are violating our security policies (chkuser)\r\n"
 #define CHKUSER_DOMAINMISSING_STRING "550 5.1.2 sorry, you must specify a domain (chkuser)\r\n"
-#define CHKUSER_RCPTFORMAT_STRING "553 5.1.3 sorry, mailbox syntax not allowed (chkuser)\r\n"
+#define CHKUSER_RCPTFORMAT_STRING "553 5.1.3 sorry, rcpt syntax not allowed (chkuser)\r\n"
 #define CHKUSER_RCPTMX_STRING "550 5.1.2 sorry, can't find a valid MX for rcpt domain (chkuser)\r\n"
-#define CHKUSER_SENDERFORMAT_STRING "553 5.1.7 sorry, mailbox syntax not allowed (chkuser)\r\n"
+#define CHKUSER_SENDERFORMAT_STRING "553 5.1.7 sorry, sender syntax not allowed (chkuser)\r\n"
 #define CHKUSER_SENDERMX_STRING "550 5.1.8 sorry, can't find a valid MX for sender domain (chkuser)\r\n"
 #define CHKUSER_INTRUSIONTHRESHOLD_STRING "550 5.7.1 sorry, you are violating our security policies (chkuser)\r\n"
 #define CHKUSER_NORELAY_STRING "553 5.7.1 sorry, that domain isn't in my list of allowed rcpthosts (chkuser)\r\n"
@@ -412,14 +382,6 @@
 #define CHKUSER_SENDERMX_TMP_STRING "451 4.4.0 DNS temporary failure (chkuser)\r\n"
 
 #define CHKUSER_MUSTAUTH_STRING "530 5.7.0 Authentication required (chkuser)\r\n"
-
-/*
- * No more used defines
- *	Following defines are eliminated since 2.0.9
- *	They will make compilation errors and must be deleted/commented
- *
- * 			#define CHKUSER_ENABLE_VAUTH_OPEN -> Substituted by CHKUSER_VAUTH_OPEN_CALL
- */
 
 /*
  * This define tells chkuser which variable must be set to accept a <#@[]> sender

--- a/qmail-smtpd.c
+++ b/qmail-smtpd.c
@@ -2410,8 +2410,8 @@ struct commands smtpcommands[] = {
 /* qsmtpdlog: start */
 void outqlog(const char *s, unsigned int n) {
   while (n > 0) {
-//    substdio_put(&sslog,((*s > 32) && (*s <= 126)) ? s : "_",1);
-    substdio_put(&sslog,s,1);
+    if (smtputf8) substdio_put(&sslog,s,1);
+    else substdio_put(&sslog,((*s > 32) && (*s <= 126)) ? s : "_",1);
     --n;
     ++s;
   }


### PR DESCRIPTION
This PR modified the following:
- make_mav() function in chkuser.c is now between #ifdef CHKUSER_SENDER_FORMAT || defined CHKUSER_RCPT_FORMAT
- more important, it returns 1 if check passed
- qmail-smtpd.c: added if(smtputf8) in outqlog function, so that it can print UTF8 chars if SMTPUTF8 has been advertised
- several comments in the new code have been improved, or dropped if obsolete