### PR TITLE
libsrs2 library linking

### DIFF
--- a/conf-cc
+++ b/conf-cc
@@ -1,3 +1,3 @@
-cc -O2 -g -DEXTERNAL_TODO -DTLS=20231230 -I`/bin/sh ./vpopmail-dir.sh`/include -DDEPRECATED_FUNCTIONS_REMOVED
+cc -O2 -g -DEXTERNAL_TODO -DTLS=20231230 -I/usr/local/include -I`/bin/sh ./vpopmail-dir.sh`/include -DDEPRECATED_FUNCTIONS_REMOVED
 
 This will be used to compile .c files.

--- a/conf-ld
+++ b/conf-ld
@@ -1,3 +1,3 @@
-cc -g
+cc -g -L/usr/local/lib
 
 This will be used to link .o files into an executable.

--- a/srs.c
+++ b/srs.c
@@ -1,7 +1,7 @@
 #include <unistd.h>
 #include <sys/types.h>
 #include <sys/stat.h>
-#include </usr/local/include/srs2.h>
+#include <srs2.h>
 #include "auto_qmail.h"
 #include "stralloc.h"
 #include "srs.h"

--- a/vpopmail-dir.sh
+++ b/vpopmail-dir.sh
@@ -35,7 +35,7 @@ if [ "$GETENT" = "" ]; then
 fi
 
 VPOPMAILDIR=$($GETENT passwd $VUSR | $CUT -d: -f6)
-if [ "$VPOPMAILDIR" != "" ]; then
+if [ -d $VPOPMAILDIR ]; then
   echo $VPOPMAILDIR
 elif [ -d /home/vpopmail ]; then
   echo "/home/vpopmail"


### PR DESCRIPTION
This PR modifies the following:
- dropped linking to srs2.h with full path </usr/local/include/srs2.h> in srs.c, it is now simply <srs2.h>
- conf-cc and conf-ld now have -L/usr/local/lib and -I/usr/local/include to look for the srs2 library
- minor correction to vpopmail dir existence check in  vpopmail-dir.sh