### PR TITLE
qmail-remote auth improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # ChangeLog
 
+- unreleased
+  - qmail-remote: authentication on remote servers can select the auth method even
+    when the first method advertized by the remote server is not available locally.  
+    ([tx Pierluigi](https://www.sagredo.eu/qmail-notes-185/smtp-auth-qmail-tls-forcetls-patch-for-qmail-84.html#comment5058))
+
 - Feb 25, 2026
   - SNI support (Tx Andreas Gerstlauer)
     https://github.com/sagredo-dev/qmail/commit/01b51166a4a295231150309129d0a3a531019af8

--- a/README.md
+++ b/README.md
@@ -265,6 +265,12 @@ This distribution of `qmail` puts together `netqmail-1.06` with the following pa
   - Thanks to Manvendra Bhangui for porting qmail-qfilter to his Indimail and to Andreas Gerstlauer for porting
     to my qmail. [Pull request](https://github.com/sagredo-dev/qmail/pull/38)
 
+* qmail-remote auth method select
+  - authentication on remote servers by qmail-remote can select the auth method even
+    when the first method advertized by the remote server is not locally available.  
+    ([tx Pierluigi](https://www.sagredo.eu/qmail-notes-185/smtp-auth-qmail-tls-forcetls-patch-for-qmail-84.html#comment5058))
+
+
 Install
 -----
 

--- a/qmail-remote.c
+++ b/qmail-remote.c
@@ -751,24 +751,36 @@ int mailfrom_cram()
 
 void smtp_auth()
 {
-  int i, j; 
+  int i, j;
 
   for (i = 0; i + 8 < smtptext.len; i += str_chr(smtptext.s+i,'\n')+1)
-    if (!str_diffn(smtptext.s+i+4,"AUTH",4)) {  
-      if ((j = str_chr(smtptext.s+i+8,'C')) > 0)
-        if (case_starts(smtptext.s+i+8+j,"CRAM"))
-          if (mailfrom_cram() >= 0) return;
-
-      if ((j = str_chr(smtptext.s+i+8,'P')) > 0)
-        if (case_starts(smtptext.s+i+8+j,"PLAIN")) 
-          if (mailfrom_plain() >= 0) return;
-
-      if ((j = str_chr(smtptext.s+i+8,'L')) > 0)
-        if (case_starts(smtptext.s+i+8+j,"LOGIN")) 
-          if (mailfrom_login() >= 0) return;
-
-      err_authprot();
-      mailfrom();
+      if (!str_diffn(smtptext.s+i+4,"AUTH",4)) {
+        int found = 0;
+        char *p = smtptext.s+i+8; /* points to first word after "AUTH " */
+        while (*p && *p != '\n') {
+          /* skip leading spaces */
+          while (*p == ' ') p++;
+            if (*p == '\n' || *p == '\0') break;
+            if (case_starts(p,"CRAM")) {
+              if (mailfrom_cram() >= 0) return;
+              found = 1; break;
+            }
+            if (case_starts(p,"PLAIN")) {
+              if (mailfrom_plain() >= 0) return;
+              if (j = str_chr(smtptext.s+i+8,'L') > 0)
+              found = 1; break;
+            }
+            if (case_starts(p,"LOGIN")) {
+              if (mailfrom_login() >= 0) return;
+              found = 1; break;
+            }
+            /* advance to next word */
+            while (*p && *p != ' ' && *p != '\n') p++;
+        }
+        if (!found) {
+          err_authprot();
+          mailfrom();
+        }
     }
 }
 


### PR DESCRIPTION
qmail-remote authentication on remote servers can select the auth method even when the first method advertised by the remote server is not available locally. (tx Pierluigi)