### PR TITLE
Remote Code Execution via Shell Injection in qmail-remote TLS Error Handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,9 @@ This distribution of `qmail` puts together `netqmail-1.06` with the following pa
 * Frederik Vermeulen's qmail-tls patch v. 20231230  
   implements SSL or TLS encrypted and authenticated SMTP.  
   The key is now 4096 bit long and the cert will be owned by vpopmail:vchkpw  
-  Patched to dinamically touch control/notlshosts/\<fqdn\> if control/notlshosts_auto contains any
-  number greater than 0 in order to skip the TLS connection for remote servers with an obsolete TLS version (tx Alexandre Fonceca).  
+  Patched to dinamically create _control/notlshosts/\<fqdn\>_ if control/notlshosts_auto contains any
+  number greater than 0 in order to skip the TLS connection for remote servers with an obsolete TLS 
+  version (tx Alexandre Fonceca for the original code and to Diep Pham for spotting a vulnerability).  
   The file update_tmprsadh was modified to chown all .pem files to vpopmail.  
   http://inoa.net/qmail-tls/
 * Marcel Telka's force-tls patch v. 2016.05.15  
@@ -265,11 +266,11 @@ This distribution of `qmail` puts together `netqmail-1.06` with the following pa
   - Thanks to Manvendra Bhangui for porting qmail-qfilter to his Indimail and to Andreas Gerstlauer for porting
     to my qmail. [Pull request](https://github.com/sagredo-dev/qmail/pull/38)
 
-* qmail-remote auth method select
-  - authentication on remote servers by qmail-remote can select the auth method even
-    when the first method advertized by the remote server is not locally available.  
-    ([tx Pierluigi](https://www.sagredo.eu/qmail-notes-185/smtp-auth-qmail-tls-forcetls-patch-for-qmail-84.html#comment5058))
-
+* Pierluigi's qmail-remote auth method select  
+  authentication on remote servers by qmail-remote can select the auth method even
+  when the first method advertized by the remote server is not locally available.  
+  ([More info here](https://www.sagredo.eu/qmail-notes-185/smtp-auth-qmail-tls-forcetls-patch-for-qmail-84.html#comment5058))  
+  ([PR here](https://github.com/sagredo-dev/qmail/pull/39))
 
 Install
 -----

--- a/qmail-remote.c
+++ b/qmail-remote.c
@@ -1,4 +1,12 @@
+#ifdef TLS
+#include <ctype.h>
+#include <string.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <stdio.h>
+#include <limits.h>
 #include <pwd.h>
+#endif
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <netinet/in.h>
@@ -395,28 +403,101 @@ void blast()
 #ifdef TLS
 char *partner_fqdn = 0;
 
+/*
+ * Validate a fully qualified domain name (FQDN)
+ * Rules enforced:
+ * - Total length: 1–255 characters
+ * - Labels separated by '.'
+ * - Each label: 1–63 characters
+ * - Allowed chars: [A-Za-z0-9-]
+ * - Labels must not start or end with '-'
+ * - FQDN must not start or end with '.'
+ */
+int is_valid_fqdn(const char *s) {
+  size_t len = strlen(s);
+  int label_len = 0;
+
+  // Check total length
+  if (len == 0 || len > 255) return 0;
+
+  // Must not start or end with '.'
+  if (s[0] == '.' || s[len-1] == '.') return 0;
+
+  for (size_t i = 0; i < len; i++) {
+    char c = s[i];
+
+    if (c == '.') {
+      // Reject empty labels or labels longer than 63 chars
+      if (label_len == 0 || label_len > 63) return 0;
+      label_len = 0;
+      continue;
+    }
+
+    // Allow only alphanumeric characters and hyphen
+    if (!isalnum((unsigned char)c) && c != '-') return 0;
+
+    // Label must not start with '-'
+    if (label_len == 0 && c == '-') return 0;
+
+    label_len++;
+  }
+
+  // Validate last label
+  if (label_len == 0 || label_len > 63) return 0;
+
+  // FQDN must not end with '-'
+  if (s[len-1] == '-') return 0;
+
+  return 1;
+}
+
+/*
+ * Create a file in control/notlshosts/<partner_fqdn>
+ */
+int create_notlshost_file(const char *pw_dir, const char *partner_fqdn) {
+  char path[PATH_MAX];
+  char fqdn_buf[256];
+  int fd;
+
+  // Check length before copying
+  if (strlen(partner_fqdn) >= sizeof(fqdn_buf)) return -1;
+
+  // Copy to local buffer
+  strcpy(fqdn_buf, partner_fqdn);
+
+  // Validate FQDN
+  if (!is_valid_fqdn(fqdn_buf)) return -1;
+
+  // Normalize to lowercase
+  for (char *p = fqdn_buf; *p; p++)
+    *p = tolower((unsigned char)*p);
+
+  // Build the full path
+  if (snprintf(path, sizeof(path),
+       "%s/control/notlshosts/%s",
+       pw_dir, fqdn_buf) >= sizeof(path))
+    return -1;
+
+  // Create the file
+  fd = open(path, O_WRONLY | O_CREAT, 0644);
+  if (fd >= 0) close(fd);
+
+  return 0;
+}
+
 # define TLS_QUIT quit(ssl ? "; connected to " : "; connecting to ", "")
 void tls_quit(const char *s1, const char *s2)
 {
   /*
-     touch control/notlshosts/<fqdn> if control/notlshosts_auto contains any
-     number greater than 0 in order to skip the TLS connection for remote
-     servers with an obsolete TLS version.
-     Thanks Alexandre Fonceca
+     Create control/notlshosts/<partner_fqdn> if control/notlshosts_auto
+     contains any number greater than 0 in order to skip the TLS
+     connection for remote servers with an obsolete TLS version.
+     Thanks Alexandre Fonceca for the original code.
+     Thanks to Diep Pham for spotting the vulnerability.
    */
-  unsigned long i = 0;
-  if (control_readint(&i,"control/notlshosts_auto") && i) {
-    struct passwd *info = getpwuid(getuid()); // get qmail dir
-    FILE *fp;
-    char acfcommand[1200];
-    sprintf(acfcommand, "/bin/touch %s/control/notlshosts/'%s'", info->pw_dir, partner_fqdn);
-    fp = popen(acfcommand, "r");
-    if (fp == NULL) {
-      out("Failed to run touch command ");
-      exit(1);
-    }
-    pclose(fp);
-  }
+  struct passwd *info = getpwuid(getuid()); // get qmail dir
+  create_notlshost_file(info->pw_dir, partner_fqdn);
+
   /* end skip TLS patch */
   out((char *)s1); if (s2) { out(": "); out((char *)s2); } TLS_QUIT;
 }

--- a/qmail-remote.c
+++ b/qmail-remote.c
@@ -4,7 +4,6 @@
 #include <fcntl.h>
 #include <unistd.h>
 #include <stdio.h>
-#include <limits.h>
 #include <pwd.h>
 #endif
 #include <sys/types.h>
@@ -454,10 +453,11 @@ int is_valid_fqdn(const char *s) {
 /*
  * Create a file in control/notlshosts/<partner_fqdn>
  */
-int create_notlshost_file(const char *pw_dir, const char *partner_fqdn) {
-  char path[PATH_MAX];
+int create_notlshost_file(const char *partner_fqdn) {
+  char path[1024];
   char fqdn_buf[256];
   int fd;
+  struct passwd *info = getpwuid(getuid()); // get qmail dir
 
   // Check length before copying
   if (strlen(partner_fqdn) >= sizeof(fqdn_buf)) return -1;
@@ -475,7 +475,7 @@ int create_notlshost_file(const char *pw_dir, const char *partner_fqdn) {
   // Build the full path
   if (snprintf(path, sizeof(path),
        "%s/control/notlshosts/%s",
-       pw_dir, fqdn_buf) >= sizeof(path))
+       info->pw_dir, fqdn_buf) >= sizeof(path))
     return -1;
 
   // Create the file
@@ -495,8 +495,7 @@ void tls_quit(const char *s1, const char *s2)
      Thanks Alexandre Fonceca for the original code.
      Thanks to Diep Pham for spotting the vulnerability.
    */
-  struct passwd *info = getpwuid(getuid()); // get qmail dir
-  create_notlshost_file(info->pw_dir, partner_fqdn);
+  create_notlshost_file(partner_fqdn);
 
   /* end skip TLS patch */
   out((char *)s1); if (s2) { out(": "); out((char *)s2); } TLS_QUIT;


### PR DESCRIPTION
Thanks to Diep Pham, who spotted this vulnerability.

When an outbound TLS handshake fails, `qmail-remote` automatically records the remote hostname in a blocklist file by executing a shell command constructed from the unsanitized DNS MX exchange name. An attacker who controls DNS records for a domain can embed shell metacharacters in the MX hostname, achieving arbitrary command execution on the mail server as the `qmailr` user. The vulnerability requires the `control/notlshosts_auto` feature to be enabled (a documented production feature for handling broken TLS hosts) and for the victim server to send or relay email to the attacker-controlled domain.