### PR TITLE
Rename rcptcheck-overlimit.cron.daily at install in /etc/cron.daily

### DIFF
--- a/config-all.sh
+++ b/config-all.sh
@@ -444,9 +444,9 @@ cp scripts/rcptcheck-overlimit QMAIL/bin
 if check_file "QMAIL/control/relaylimits"; then
   echo ":1000" > QMAIL/control/relaylimits
 fi
-if check_file "/etc/cron.daily/rcptcheck-overlimit.cron.daily"; then
+if check_file "/etc/cron.daily/rcptcheck-overlimit"; then
   echo "Installing 'overlimit' cronjob in /etc/cron.daily..."
-  cp scripts/rcptcheck-overlimit.cron.daily /etc/cron.daily
+  cp scripts/rcptcheck-overlimit.cron.daily /etc/cron.daily/rcptcheck-overlimit
 fi
 
 ############ svtools


### PR DESCRIPTION
Hi, cron.daily do not execute files with dot extension

# l
total 28
-rwxr-xr-x 1 root root  311 Apr 23  2025 0anacron
-rwxr-xr-x 1 root root 1478 Jun 24  2025 apt-compat
-rwxr-xr-x 1 root root  123 May 27  2025 dpkg
-rwxr-xr-x 1 root root  377 Jul 14  2024 logrotate
-rwxr-xr-x 1 root root 1395 May  2  2025 man-db
-rw-r--r-- 1 root root  102 Jun 13  2025 .placeholder
-rwxr-xr-x 1 root root 1696 Apr 13 07:37 rcptcheck-overlimit.cron.daily

# run-parts --test /etc/cron.daily
/etc/cron.daily/0anacron
/etc/cron.daily/apt-compat
/etc/cron.daily/dpkg
/etc/cron.daily/logrotate
/etc/cron.daily/man-db

# mv rcptcheck-overlimit.cron.daily rcptcheck-overlimit

# run-parts --test /etc/cron.daily
/etc/cron.daily/0anacron
/etc/cron.daily/apt-compat
/etc/cron.daily/dpkg
/etc/cron.daily/logrotate
/etc/cron.daily/man-db
/etc/cron.daily/rcptcheck-overlimit