### PR TITLE
Initialize embedded stralloc objects in token822_ready()

### DIFF
--- a/custom_error.c
+++ b/custom_error.c
@@ -20,7 +20,7 @@ custom_error(const char *program, const char *type, const char *message, const c
 		errfd = CUSTOM_ERR_FD;
 	else
 		scan_int(c, &errfd);
-  substdio_fdbuf(&sserr, write, errfd, errbuf, sizeof(errbuf));
+	substdio_fdbuf(&sserr, write, errfd, errbuf, sizeof(errbuf));
 	if (substdio_put(&sserr, type, 1) == -1 ||
 			substdio_puts(&sserr, program) == -1 ||
 			substdio_put(&sserr, ": ", 2) ||

--- a/token822.c
+++ b/token822.c
@@ -21,9 +21,65 @@ void token822_reverse(token822_alloc *ta)
   }
 }
 
-GEN_ALLOC_readyplus(token822_alloc, struct token822, t, len, a, i, n, x, 30, token822_readyplus)
-GEN_ALLOC_ready(token822_alloc, struct token822, t, len, a, i, n, x, 30, token822_ready)
 GEN_ALLOC_append(token822_alloc, struct token822, t, len, a, i, n, x, 30, token822_readyplus, token822_append)
+
+/*
+ * token822 contains embedded stralloc objects.
+ * Every newly allocated token must have addr initialized to
+ * { NULL, 0, 0 }, otherwise stralloc_ready() may attempt to
+ * realloc/free an uninitialized pointer.
+ */
+int token822_ready(token822_alloc *x, unsigned int n)
+{
+    unsigned int olda;
+    unsigned int i;
+
+    if (x->t) {
+        olda = x->a;
+
+        if (n <= olda)
+            return 1;
+
+        x->a = 30 + n + (n >> 3);
+
+        if (!alloc_re((char **)&x->t,
+                      olda * sizeof(struct token822),
+                      x->a * sizeof(struct token822))) {
+            x->a = olda;
+            return 0;
+        }
+
+        for (i = olda; i < x->a; ++i) {
+            x->t[i].addr.s = 0;
+            x->t[i].addr.len = 0;
+            x->t[i].addr.a = 0;
+            x->t[i].type = 0;
+        }
+
+        return 1;
+    }
+
+    x->len = 0;
+    x->a = n;
+
+    x->t = (struct token822 *) alloc(n * sizeof(struct token822));
+    if (!x->t)
+        return 0;
+
+    for (i = 0; i < n; ++i) {
+        x->t[i].addr.s = 0;
+        x->t[i].addr.len = 0;
+        x->t[i].addr.a = 0;
+        x->t[i].type = 0;
+    }
+
+    return 1;
+}
+
+int token822_readyplus(token822_alloc *x, unsigned int n)
+{
+    return token822_ready(x, x->len + n);
+}
 
 static int needspace(int t1, int t2)
 {


### PR DESCRIPTION
The previous refactoring replaced char *s/int slen with an embedded stralloc inside struct token822. Newly allocated token822 objects were left uninitialized, causing stralloc_ready() to attempt alloc_re() on garbage pointers. Initialize every newly allocated token822 in token822_ready() after allocation/reallocation.